### PR TITLE
feat: Support `X-API-Key` header authentication

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup
-      - run: bun test
-        env:
-          BASE_URL: http://localhost
   check:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup
       - run: bun test
+        env:
+          BASE_URL: http://localhost
   check:
     runs-on: ubuntu-24.04
     steps:

--- a/README.md
+++ b/README.md
@@ -17,12 +17,17 @@ services:
       USERNAME: your-username                     # Required, username to login with
       PASSWORD: your-password                     # Required, password to login with
       PORT: 3000                                  # Optional, default 3000
+      API_KEY: your-api-key                       # Optional, set to a any string to require authentication
 ```
 
 To tell Portainer to pull the latest images and update the stack, make a simple POST request:
 
 ```sh
+# No authentication
 curl -X POST http://localhost:3000/api/webhook/stacks/:stackId
+
+# With an API key
+curl -X POST -H "X-API-Key: <your-api-key>" http://localhost:3000/api/webhook/stacks/:stackId
 ```
 
 You can get the `stackId` from the `GET /api/stacks` endpoint.
@@ -36,6 +41,8 @@ To install dependencies:
 ```bash
 bun install
 ```
+
+`@aklinker1/zeta` docs: https://jsr.io/@aklinker1/zeta
 
 To run:
 
@@ -52,7 +59,7 @@ To run:
    curl -X POST http://localhost:3000/api/webhook/stacks/123
    ```
 
-You can also run tests:
+To run tests:
 
 ```sh
 bun test

--- a/openapi.json
+++ b/openapi.json
@@ -61,7 +61,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Stack update submitted"
+            "description": "Accepted"
           },
           "400": {
             "description": "Bad Request",

--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -7,6 +7,9 @@ import { version } from "../version";
 import { portainerStackFactory } from "../testing/factories";
 import { env } from "../env";
 
+mock.module("../env", () => ({
+  env: {},
+}));
 const API_KEY = "random-text";
 
 const portainer = mockPortainer;

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -1,4 +1,4 @@
-import { bold, cyan, violet } from "./colors";
+import { bold, cyan, dim, violet } from "./colors";
 import { env } from "./env";
 import "./index";
 
@@ -6,5 +6,5 @@ const res = await fetch(`http://localhost:${env.port}/openapi.json`);
 const json = await res.json();
 Bun.write("openapi.json", JSON.stringify(json, null, 2));
 console.log(
-  `${cyan(bold("ℹ"))} OpenAPI spec written to ${violet("openapi.json")}`,
+  `${cyan(bold("ℹ"))} ${dim("[dev]")} OpenAPI spec written to ${violet("openapi.json")}`,
 );

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,13 @@
+import { violet, bold, cyan, red } from "./colors";
+
 function requireEnv(key: string): string {
   const value = process.env[key];
-  if (!value) throw new Error(`Missing required environment variable: ${key}`);
+  if (!value) {
+    console.log(
+      `${red(bold("⚠ Fatal"))}: The ${violet(key)} env var is required`,
+    );
+    process.exit(1);
+  }
   return value;
 }
 
@@ -9,4 +16,17 @@ export const env = {
   baseUrl: requireEnv("BASE_URL"),
   username: requireEnv("USERNAME"),
   password: requireEnv("PASSWORD"),
+  apiKey: process.env.API_KEY || undefined,
 };
+
+export function logEnvWarnings() {
+  if (env.apiKey) {
+    console.log(
+      `${cyan(bold("ℹ"))} ${violet("API_KEY")} set - endpoints are protected`,
+    );
+  } else {
+    console.log(
+      `${cyan(bold("ℹ"))} ${violet("API_KEY")} not set - endpoints are not protected`,
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import { blue, cyan, dim, violet } from "./colors";
+import { bold, cyan, dim, violet } from "./colors";
 import { version } from "./version";
 import { app } from "./app";
 import { env, logEnvWarnings } from "./env";
 
-console.log(`${cyan(blue("Portainer Stack Webhooks"))} ${dim("v" + version)}`);
+console.log(`${bold(cyan("Portainer Stack Webhooks"))} ${dim("v" + version)}`);
 
 app.listen(env.port, () => {
   logEnvWarnings();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
-import { bold, cyan, dim, violet } from "./colors";
+import { blue, cyan, dim, violet } from "./colors";
 import { version } from "./version";
 import { app } from "./app";
-import { env } from "./env";
+import { env, logEnvWarnings } from "./env";
 
-console.log(`${bold(cyan("Portainer Stack Webhooks"))} ${dim("v" + version)}`);
+console.log(`${cyan(blue("Portainer Stack Webhooks"))} ${dim("v" + version)}`);
 
 app.listen(env.port, () => {
+  logEnvWarnings();
+
   console.log(
     `${cyan("ℹ")} Server started ${dim("→")} ${violet(
       "http://localhost:" + env.port,

--- a/src/plugins/auth-plugin.ts
+++ b/src/plugins/auth-plugin.ts
@@ -1,7 +1,15 @@
-import { createApp } from "@aklinker1/zeta";
+import { createApp, UnauthorizedHttpError } from "@aklinker1/zeta";
+import { env } from "../env";
 
 export const authPlugin = createApp()
-  .onTransform(({ headers: _ }) => {
-    // TODO: Throw UnauthorizedHttpError if the API key is missing or invalid
+  .onTransform(({ request }) => {
+    // Allow unauthenticated requests if no API key is provided
+    if (!env.apiKey) return;
+
+    const apiKey = request.headers.get("x-api-key");
+    if (!apiKey)
+      throw new UnauthorizedHttpError("X-API-Key header is required");
+    if (apiKey !== env.apiKey)
+      throw new UnauthorizedHttpError("Invalid API key");
   })
   .export();


### PR DESCRIPTION
If the env var is not set, no auth is required.

See new README for details on how to set the `API_KEY` env var.