### PR TITLE
chore: Rename env vars to add `PORTAINER_` prefix

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,3 @@
-PORTAINER_BASE_URL=https://portainer.example.com/api
+PORTAINER_API_URL=https://portainer.example.com/api
 PORTAINER_USERNAME=admin
 PORTAINER_PASSWORD=password

--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,3 @@
-BASE_URL=https://portainer.example.com/api
-USERNAME=admin
-PASSWORD=password
+PORTAINER_BASE_URL=https://portainer.example.com/api
+PORTAINER_USERNAME=admin
+PORTAINER_PASSWORD=password

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ services:
     ports:
       - 3000:3000
     environment:
-      BASE_URL: https://portainer.example.com/api # Required, full URL including /api
-      USERNAME: your-username                     # Required, username to login with
-      PASSWORD: your-password                     # Required, password to login with
-      PORT: 3000                                  # Optional, default 3000
-      API_KEY: your-api-key                       # Optional, set to a any string to require authentication
+      PORTAINER_BASE_URL: https://portainer.example.com/api # Required, full URL including /api
+      PORTAINER_USERNAME: your-username                     # Required, username to login with
+      PORTAINER_PASSWORD: your-password                     # Required, password to login with
+      PORT: 3000                                            # Optional, default 3000
+      API_KEY: your-api-key                                 # Optional, set to a any string to require authentication
 ```
 
 To tell Portainer to pull the latest images and update the stack, make a simple POST request:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ services:
     ports:
       - 3000:3000
     environment:
-      PORTAINER_BASE_URL: https://portainer.example.com/api # Required, full URL including /api
+      PORTAINER_API_URL: https://portainer.example.com/api  # Required, full URL including /api
       PORTAINER_USERNAME: your-username                     # Required, username to login with
       PORTAINER_PASSWORD: your-password                     # Required, password to login with
       PORT: 3000                                            # Optional, default 3000

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Portainer Stack Webhook",
-    "version": "0.2.1"
+    "version": "0.2.2"
   },
   "paths": {
     "/api/health": {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,4 @@
-import { violet, bold, cyan, red } from "./colors";
+import { violet, bold, cyan, red, yellow } from "./colors";
 
 function requireEnv(key: string): string {
   const value = process.env[key];
@@ -13,9 +13,11 @@ function requireEnv(key: string): string {
 
 export const env = {
   port: Number(process.env.PORT || 3000),
-  baseUrl: requireEnv("BASE_URL"),
-  username: requireEnv("USERNAME"),
-  password: requireEnv("PASSWORD"),
+  portainer: {
+    baseUrl: process.env.BASE_URL || requireEnv("PORTAINER_BASE_URL"),
+    username: process.env.USERNAME || requireEnv("PORTAINER_USERNAME"),
+    password: process.env.PASSWORD || requireEnv("PORTAINER_PASSWORD"),
+  },
   apiKey: process.env.API_KEY || undefined,
 };
 
@@ -28,5 +30,13 @@ export function logEnvWarnings() {
     console.log(
       `${cyan(bold("ℹ"))} ${violet("API_KEY")} not set - endpoints are not protected`,
     );
+  }
+
+  for (const key of ["BASE_URL", "USERNAME", "PASSWORD"]) {
+    if (process.env[key]) {
+      console.log(
+        `${yellow(bold("⚠"))} ${violet(key)} is deprecated, use ${violet("PORTAINER_" + key)} instead`,
+      );
+    }
   }
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -14,7 +14,7 @@ function requireEnv(key: string): string {
 export const env = {
   port: Number(process.env.PORT || 3000),
   portainer: {
-    baseUrl: process.env.BASE_URL || requireEnv("PORTAINER_BASE_URL"),
+    baseUrl: process.env.BASE_URL || requireEnv("PORTAINER_API_URL"),
     username: process.env.USERNAME || requireEnv("PORTAINER_USERNAME"),
     password: process.env.PASSWORD || requireEnv("PORTAINER_PASSWORD"),
   },

--- a/src/env.ts
+++ b/src/env.ts
@@ -32,11 +32,15 @@ export function logEnvWarnings() {
     );
   }
 
-  for (const key of ["BASE_URL", "USERNAME", "PASSWORD"]) {
-    if (process.env[key]) {
-      console.log(
-        `${yellow(bold("⚠"))} ${violet(key)} is deprecated, use ${violet("PORTAINER_" + key)} instead`,
-      );
-    }
+  maybeLogDeprecated("BASE_URL", "PORTAINER_API_URL");
+  maybeLogDeprecated("USERNAME", "PORTAINER_USERNAME");
+  maybeLogDeprecated("PASSWORD", "PORTAINER_PASSWORD");
+}
+
+function maybeLogDeprecated(key: string, replacement: string): void {
+  if (process.env[key]) {
+    console.log(
+      `${yellow(bold("⚠"))} ${violet(key)} is deprecated, use ${violet(replacement)} instead`,
+    );
   }
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -14,7 +14,7 @@ function requireEnv(key: string): string {
 export const env = {
   port: Number(process.env.PORT || 3000),
   portainer: {
-    baseUrl: process.env.BASE_URL || requireEnv("PORTAINER_API_URL"),
+    apiUrl: process.env.BASE_URL || requireEnv("PORTAINER_API_URL"),
     username: process.env.USERNAME || requireEnv("PORTAINER_USERNAME"),
     password: process.env.PASSWORD || requireEnv("PORTAINER_PASSWORD"),
   },

--- a/src/utils/portainer.ts
+++ b/src/utils/portainer.ts
@@ -9,7 +9,7 @@ export interface PortainerApi {
 }
 
 export async function createPortainerApi(): Promise<PortainerApi> {
-  const { baseUrl, username, password } = env.portainer;
+  const { apiUrl, username, password } = env.portainer;
 
   const checkResponse = (response: Response, expectedStatus = 200) => {
     if (response.status !== expectedStatus)
@@ -17,7 +17,7 @@ export async function createPortainerApi(): Promise<PortainerApi> {
   };
 
   const login = async (): Promise<PortainerLoginResponse> => {
-    const res = await fetch(`${baseUrl}/auth`, {
+    const res = await fetch(`${apiUrl}/auth`, {
       body: JSON.stringify({ username, password }),
       method: "POST",
       headers: {
@@ -34,7 +34,7 @@ export async function createPortainerApi(): Promise<PortainerApi> {
   };
 
   const listStacks: PortainerApi["listStacks"] = async () => {
-    const res = await fetch(`${baseUrl}/stacks`, {
+    const res = await fetch(`${apiUrl}/stacks`, {
       headers: authHeaders,
     });
 
@@ -43,7 +43,7 @@ export async function createPortainerApi(): Promise<PortainerApi> {
   };
 
   const getStack: PortainerApi["getStack"] = async (id) => {
-    const res = await fetch(`${baseUrl}/stacks/${id}`, {
+    const res = await fetch(`${apiUrl}/stacks/${id}`, {
       headers: authHeaders,
     });
 
@@ -52,7 +52,7 @@ export async function createPortainerApi(): Promise<PortainerApi> {
   };
 
   const getStackFile: PortainerApi["getStackFile"] = async (id) => {
-    const res = await fetch(`${baseUrl}/stacks/${id}/file`, {
+    const res = await fetch(`${apiUrl}/stacks/${id}/file`, {
       headers: authHeaders,
     });
 
@@ -64,7 +64,7 @@ export async function createPortainerApi(): Promise<PortainerApi> {
     id,
     options,
   ): Promise<void> => {
-    const updateUrl = new URL(`${baseUrl}/stacks/${id}`);
+    const updateUrl = new URL(`${apiUrl}/stacks/${id}`);
     updateUrl.searchParams.set("endpointId", String(options.endpointId));
 
     const res = await fetch(updateUrl.href, {

--- a/src/utils/portainer.ts
+++ b/src/utils/portainer.ts
@@ -9,7 +9,7 @@ export interface PortainerApi {
 }
 
 export async function createPortainerApi(): Promise<PortainerApi> {
-  const { baseUrl, username, password } = env;
+  const { baseUrl, username, password } = env.portainer;
 
   const checkResponse = (response: Response, expectedStatus = 200) => {
     if (response.status !== expectedStatus)


### PR DESCRIPTION
Maintain backwards compatibility with the old `USERNAME`, `PASSWORD`, and `BASE_URL` env vars. Log them as deprecated, but respect them.